### PR TITLE
Build new binder image via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,3 +77,7 @@ install:
   - pip install tox-travis
 
 script: tox
+
+after_script:
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl https://mybinder.org/v2/gh/students-teach-students/python-tools-for-students/master?urlpath=lab; fi
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/s-weigand/python-tools-for-students.svg?branch=master)](https://travis-ci.org/s-weigand/python-tools-for-students)
-[![Build status](https://ci.appveyor.com/api/projects/status/05xsqpqt74uxjyfa?svg=true)](https://ci.appveyor.com/project/s-weigand/python-tools-for-students)
+[![Build Status](https://travis-ci.org/s-weigand/python-tools-for-students.svg?branch=master)](https://travis-ci.org/students-teach-students/python-tools-for-students)
+[![Build status](https://ci.appveyor.com/api/projects/status/05xsqpqt74uxjyfa?svg=true)](https://ci.appveyor.com/project/students-teach-students/python-tools-for-students)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/students-teach-students/python-tools-for-students/master?urlpath=lab)
 
 # python-tools-for-students


### PR DESCRIPTION
Since it takes a long time to build the binder image of the repo, this should be done automatically by travis, as soon as a PR gets merged into master.