### PR TITLE
changed nbval comments in favor of tags

### DIFF
--- a/material/#1_Using-Jupyter-Lab/#1_Using-Jupyter-Lab.ipynb
+++ b/material/#1_Using-Jupyter-Lab/#1_Using-Jupyter-Lab.ipynb
@@ -208,7 +208,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -355,7 +359,6 @@
     }
    ],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
     "%lsmagic"
    ]
   },
@@ -376,31 +379,27 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total 32\n",
-      "drwxrwxrwx 1 root root  4096 Sep 23 16:37 .\n",
-      "drwxrwxrwx 1 root root  4096 Sep 23 13:28 ..\n",
-      "-rwxrwxrwx 1 root root 28827 Sep 23 16:37 #1_Using-Jupyter-Lab.ipynb\n",
-      "drwxrwxrwx 1 root root  4096 Sep 23 15:09 images\n",
-      "drwxrwxrwx 1 root root  4096 Aug 30 17:58 .ipynb_checkpoints\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "stdin: is not a tty\n"
+      "total 28\n",
+      "-rwxrwxrwx 1 sebastian sebastian 27333 Sep 24 19:18 #1_Using-Jupyter-Lab.ipynb\n",
+      "drwxrwxrwx 1 sebastian sebastian  4096 Sep 24 19:18 .\n",
+      "drwxrwxrwx 1 sebastian sebastian  4096 Sep 24 18:03 ..\n",
+      "drwxrwxrwx 1 sebastian sebastian  4096 Sep 24 18:07 .ipynb_checkpoints\n",
+      "drwxrwxrwx 1 sebastian sebastian  4096 Sep 24 18:03 images\n"
      ]
     }
    ],
    "source": [
     "%%bash\n",
-    "# NBVAL_IGNORE_OUTPUT\n",
     "ls -la"
    ]
   },
@@ -422,23 +421,26 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total 32\n",
-      "-rw-r--r-- 1 dafuq 197121 28827 Sep 23 16:37 #1_Using-Jupyter-Lab.ipynb\n",
-      "drwxr-xr-x 1 dafuq 197121     0 Sep 23 16:37 .\n",
-      "drwxr-xr-x 1 dafuq 197121     0 Sep 23 13:28 ..\n",
-      "drwxr-xr-x 1 dafuq 197121     0 Aug 30 17:58 .ipynb_checkpoints\n",
-      "drwxr-xr-x 1 dafuq 197121     0 Sep 23 15:09 images\n"
+      "total 36\n",
+      "-rw-r--r-- 1 sebastian 197121 27333 Sep 24 19:18 #1_Using-Jupyter-Lab.ipynb\n",
+      "drwxr-xr-x 1 sebastian 197121     0 Sep 24 19:18 .\n",
+      "drwxr-xr-x 1 sebastian 197121     0 Sep 24 18:03 ..\n",
+      "drwxr-xr-x 1 sebastian 197121     0 Sep 24 18:07 .ipynb_checkpoints\n",
+      "drwxr-xr-x 1 sebastian 197121     0 Sep 24 18:03 images\n"
      ]
     }
    ],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
     "!ls -la"
    ]
   },
@@ -476,7 +478,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -495,14 +501,17 @@
     }
    ],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
     "%%bash?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -521,7 +530,6 @@
     }
    ],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
     "?%%bash"
    ]
   },
@@ -569,7 +577,9 @@
     "* [Variableinspector](https://github.com/lckr/jupyterlab-variableInspector)\n",
     "    Adds a tab showing the variables which exist in the current session.\n",
     "* [Code Formatter](https://github.com/ryantam626/jupyterlab_code_formatter)\n",
-    "    Formats your code in the selected style."
+    "    Formats your code in the selected style.\n",
+    "* [Jupyterlab Celltags](https://github.com/jupyterlab/jupyterlab-celltags)\n",
+    "    Allows to add ``Tags`` (meta information) to cells."
    ]
   },
   {
@@ -622,7 +632,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-raises-exception"
+    ]
+   },
    "outputs": [
     {
      "ename": "ModuleNotFoundError",
@@ -631,13 +645,12 @@
      "traceback": [
       "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-6-b3743609198f>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;31m# NBVAL_RAISES_EXCEPTION\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mnot_a_valid_module\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m<ipython-input-6-b58700dcf11b>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mnot_a_valid_module\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'not_a_valid_module'"
      ]
     }
    ],
    "source": [
-    "# NBVAL_RAISES_EXCEPTION\n",
     "import not_a_valid_module"
    ]
   }


### PR DESCRIPTION
This is just a minor change which makes notebooks look more clean, since it isn't important for the user to see the inner works of our testing.
For more information see https://nbval.readthedocs.io/en/latest/index.html#Using-tags-instead-of-comments
To add tags [jupyterlab-celltags](https://github.com/jupyterlab/jupyterlab-celltags) was used.