### PR TITLE
Fix docs html styling problem with 'sphinx-copybutton'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ docs/**/**/images/
 
 # this is just a symlinks and needs no changing
 docs/readme.md
+
+# map files for the css, generated from the scss files
+*.css.map

--- a/docs/_static/css/copy-btn-overwrite.css
+++ b/docs/_static/css/copy-btn-overwrite.css
@@ -1,0 +1,28 @@
+div.nbinput div.input_area,
+div.nboutput div.output_area {
+  padding: 0 !important;
+}
+
+div.nbinput,
+div.nbinput div.prompt,
+div.nbinput div.input_area,
+div.nbinput div[class*="highlight"],
+div.nbinput div[class*="highlight"] pre,
+div.nboutput,
+div.nbinput div.prompt,
+div.nbinput div.output_area,
+div.nboutput div[class*="highlight"],
+div.nboutput div[class*="highlight"] pre {
+  padding: 0.2em !important;
+}
+
+a.copybtn {
+  padding: 0;
+  width: 0.8em;
+  height: 0.8em;
+}
+
+.prompt.highlight-none.notranslate a.copybtn {
+  display: none;
+}
+/*# sourceMappingURL=copy-btn-overwrite.css.map */

--- a/docs/_static/css/copy-btn-overwrite.scss
+++ b/docs/_static/css/copy-btn-overwrite.scss
@@ -1,0 +1,28 @@
+div.nbinput div.input_area,
+div.nboutput div.output_area {
+  padding: 0 !important;
+}
+div.nbinput,
+div.nbinput div.prompt,
+div.nbinput div.input_area,
+div.nbinput div[class*="highlight"],
+div.nbinput div[class*="highlight"] pre,
+div.nboutput,
+div.nbinput div.prompt,
+div.nbinput div.output_area,
+div.nboutput div[class*="highlight"],
+div.nboutput div[class*="highlight"] pre {
+  padding: 0.2em !important;
+}
+
+a.copybtn {
+  padding: 0;
+  width: 0.8em;
+  height: 0.8em;
+}
+
+.prompt.highlight-none.notranslate {
+  a.copybtn {
+    display: none;
+  }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------
@@ -245,3 +245,6 @@ texinfo_documents = [
     )
 ]
 
+
+def setup(app):
+    app.add_stylesheet("css/copy-btn-overwrite.css")


### PR DESCRIPTION
**Pure tooling change, I will merge this PR myself.**

Changed some css, to make the icons from 'sphinx-copybutton', being prettier and not cause overflow.

**Before:**
![wrong_output](https://user-images.githubusercontent.com/9513634/66274034-9978dd80-e87a-11e9-83a7-e0fa5e1b5fc9.jpg)

**After:**
![corrected-css](https://user-images.githubusercontent.com/9513634/66274037-9e3d9180-e87a-11e9-98a6-182af4f7b876.jpg)

**Note:** The strange characters come from a problem with `ansi-in-text` in `jupyter lab` output cells ([see](https://github.com/spatialaudio/nbsphinx/issues/330)).
