### PR TITLE
[Tooling] Replace make command with actual sphinx commands in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,9 @@ jobs:
           pip freeze
           pandoc -v
       - name: Build docs
-        run: make --directory=docs clean html
+        run: |
+          rm -rf docs/_build
+          python -m sphinx -b html docs docs/_build
 
   docs-link:
     runs-on: ubuntu-latest
@@ -55,7 +57,9 @@ jobs:
           pandoc -v
       - name: Build docs
         continue-on-error: true
-        run: make --directory=docs clean linkcheck
+        run: |
+          rm -rf docs/_build
+          python -m sphinx -b linkcheck docs docs/_build
 
   test:
     runs-on: ${{ matrix.os }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 minversion = 3.4.0
+skip_missing_interpreters = True
 skipsdist = True
 envlist = py{36,37,38}, docs, docs-links, flake8-nb
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,19 @@
 [tox]
 minversion = 3.4.0
 skipsdist = True
-envlist = py{36,37}, docs, docs-links, flake8-nb
+envlist = py{36,37,38}, docs, docs-links, flake8-nb
 
 [flake8]
 max-line-length = 99
 
 
 [testenv:docs]
-whitelist_externals = make
 commands =
-  make --directory=docs clean html
+  {envpython} -m sphinx -a -b html docs docs/_build
 
 [testenv:docs-links]
-whitelist_externals = make
 commands =
-  make --directory=docs clean linkcheck
+  {envpython} -m sphinx -a -b linkcheck docs docs/_build
 
 
 [testenv:flake8-nb]


### PR DESCRIPTION
**Pure tooling change, I will merge this PR myself.**

By replacing the `make` command in `tox.ini`, with the `sphinx` command, which `make` would call, the `tox` tests can also be run from `cmd`/`powershell`.

Also added `py38` test to `tox.ini` and  made tox skip tests with missing interpreters.