### PR TITLE
Mention that 'Jupyterlab Celltags' in part of jupyterlab 2.0

### DIFF
--- a/material/1_Using-Jupyter-Lab/1_Using-Jupyter-Lab.ipynb
+++ b/material/1_Using-Jupyter-Lab/1_Using-Jupyter-Lab.ipynb
@@ -592,7 +592,7 @@
     "    Formats your code in the selected style.\n",
     "    \n",
     "* [Jupyterlab Celltags](https://github.com/jupyterlab/jupyterlab-celltags)\n",
-    "    Allows to add ``Tags`` (meta information) to cells.\n",
+    "    Allows to add ``Tags`` (meta information) to cells. This addon is part of the jupyter lab core since the 2.0 release.\n",
     "    \n",
     "* [Jupyterlab TOC](https://github.com/jupyterlab/jupyterlab-toc)\n",
     "    Adds a TOC (Table of Content) navigation panel.\n",


### PR DESCRIPTION
Added information that ['Jupyterlab Celltags' is part of jupyterlab core since 2.0 release](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#v2-0-0).